### PR TITLE
Fandom is switching to a new authentication system

### DIFF
--- a/src/api/api_interface.ts
+++ b/src/api/api_interface.ts
@@ -24,7 +24,9 @@ export const config = {
 const headers = {
   'User-Agent': config.UA,
   'Content-Type': 'application/x-www-form-urlencoded',
-  cookie: `access_token=${config.ACCESS_TOKEN}`,
+  cookie: `fandom_session=${config.ACCESS_TOKEN}`,
+  // required only during the transition period, can be removed after April
+  'X-Fandom-Auth': 1,
 };
 
 export class ApiInterface {


### PR DESCRIPTION
Please check https://community.fandom.com/wiki/User_blog:TimmyQuivy/Introducing_Fandom_Auth_-_Our_New_Secure_Login_Service for more information.

Fandom is switching to a new authentication system that's using `fandom_session` cookie instead of `access_token`. The `access_token` tokens will begin to be invalidated starting this week.

During the transition process, a `X-Fandom-Auth:1` header needs to be provided for API calls to switch to the new auth system. This is only necessary until Fandom Auth is enabled by default for all users, something that should happen by the end of April. For the browser the header is added automatically based on the users' rollout status.